### PR TITLE
[Fix] Linking error when using GCC > 10

### DIFF
--- a/src/dyn_ring_queue.c
+++ b/src/dyn_ring_queue.c
@@ -11,6 +11,11 @@
 #include "dyn_gossip.h"
 #include "dyn_token.h"
 
+// This fix the linking error if GCC is greater than 10.
+// Source: https://github.com/dmolik/dynomite/commit/303d4ecae95aee9540c48ceac9e7c0f2137a4b52
+_C2G_InQ C2G_InQ = {};
+_C2G_OutQ C2G_OutQ = {};
+
 // should use pooling to store struct ring_message so that we can reuse
 struct ring_msg *create_ring_msg(void) {
   struct ring_msg *msg = dn_alloc(sizeof(*msg));

--- a/src/dyn_ring_queue.h
+++ b/src/dyn_ring_queue.h
@@ -16,17 +16,22 @@ struct gossip_node;
 typedef rstatus_t (*callback_t)(void *msg);
 typedef void (*data_func_t)(void *);
 
-volatile struct {
+// This fix the linking error if GCC is greater than 10.
+// Source: https://github.com/dmolik/dynomite/commit/303d4ecae95aee9540c48ceac9e7c0f2137a4b52
+typedef volatile struct {
   long m_getIdx;
   long m_putIdx;
   void *m_entry[C2G_InQ_SIZE];
-} C2G_InQ;
+} _C2G_InQ;
 
-volatile struct {
+typedef volatile struct {
   long m_getIdx;
   long m_putIdx;
   void *m_entry[C2G_OutQ_SIZE];
-} C2G_OutQ;
+} _C2G_OutQ;
+
+extern _C2G_InQ C2G_InQ;
+extern _C2G_OutQ C2G_OutQ;
 
 struct ring_msg {
   callback_t cb;


### PR DESCRIPTION
This PR is to fix the following issues...
* Fix the linking error caused by duplicated definitions. For more detail, please refer to this [issue](https://github.com/Netflix/dynomite/issues/802)